### PR TITLE
Fix pickadate error

### DIFF
--- a/inputTypes/pickadate/pickadate.js
+++ b/inputTypes/pickadate/pickadate.js
@@ -20,8 +20,8 @@ AutoForm.addInputType('pickadate', {
     return result;
   },
   valueOut: function() {
-    var item, result;
-    item = this.pickadate('picker').get('select');
+    var item, result, picker = this.pickadate('picker');
+    item = picker && picker.get('select');
     if (item) {
       result = item.obj;
     }


### PR DESCRIPTION
This fixes a bug when pickadate is not yet initialized

```
TypeError: Cannot read property 'get' of undefined
```
